### PR TITLE
Add single file watch mode clarification to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ This software is very much at alpha stage. If you want to help, here are a few t
   - [ ] Provide better summary that shows errors by file/test (behind an option flag)
   - [ ] Show deltas (+/- change) since last run (would require caching)
 - [ ] Known issues
-  - [ ] When running Jest with a single file parameter (e.g. `jest src/file.js`), the reporter is not activated
+  - [ ] When running Jest with a single file parameter (e.g. `jest src/file.js`, or a single file running in watch mode), the reporter is not activated
 
 ## License
 


### PR DESCRIPTION
Related to #5 

Adds a clarification to the Readme that the known single file parameter issue also applies to when a single file is running in watch mode which seems obvious in hindsight, but I misunderstood when I first read it. 😄 