### PR TITLE
Reference @jest/reporters version specifically

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ module.exports = {
     // Overriding config.reporters wipes out default reporters, so
     // we need to restore the summary reporter.
     //
-    // NOTE: For jest 26.6.1 or older, this file is located at
+    // NOTE: For @jest/reporters 26.6.1 or older, this file is located at
     // @jest/reporters/build/summary_reporter
     "@jest/reporters/build/SummaryReporter",
   ],
@@ -70,9 +70,9 @@ module.exports = {
 
 ## Options
 
-Pass options to the reporter in your jest configuration as follows:
+Pass options to the reporter in your jest configuration as follows. Your version of `@jest/reporters` is likely the same as your base Jest version, but it's possible that the minor version is more recent. You can determine your specific version by running `npm ls @jest/reporters`.
 
-### Using Jest 26.6.2 or newer
+### Using @jest/reporters 26.6.2 or newer
 
 ```js
 const jestConfig = {
@@ -83,7 +83,7 @@ const jestConfig = {
 };
 ```
 
-### Using Jest 25.1.0-26.6.1
+### Using @jest/reporters 25.1.0-26.6.1
 
 ```js
 const jestConfig = {


### PR DESCRIPTION
This is actually the package version that matters here, and with `@jest/core`'s `package.json` it's quite possible to have e.g. `jest@26.6.0` but `@jest/reporters@26.6.3`, so referencing the `jest` version will not always give you the correct answer.

I know this because this is exactly the situation I'm in:
```
› npm ls @jest/reporters
[snip]
└─┬ jest-clean-console-reporter@0.3.0
  └─┬ jest@26.6.0
    └─┬ @jest/core@26.6.3
      └── @jest/reporters@26.6.2
```
So, I initially tried to use `summary_reporters` and got an error, even though I'm on `jest@26.6.0`, because I have `@jest/reporters@26.6.2`